### PR TITLE
Added fields to quoteRequest.json

### DIFF
--- a/src/general/quoteRequest.json
+++ b/src/general/quoteRequest.json
@@ -4,8 +4,12 @@
     "lenderFileNumber": "BANK12345",
     "selectedAccountId": "0a9feeb3-41d5-11e9-92a8-0242ac1b0002",
     "selectedBranch": "6a9feeb3-41d5-11e9-92a8-0242ac1b0555",
+    "selectedUnderwriterId": "4e7cedbe-404c-11e9-9a44-0242ac170002",
     "transactionFileCreated": "8/18/2016",
     "transactionFileType": "Refinance",
+    "propertyType": "Residential",
+    "appraisalForm": 1004,
+    "appraisalType": "ALL",
     "property": {
       "address": {
         "line1": "123 N. Street",
@@ -36,6 +40,7 @@
     },
     "policiesRequested": [
       {
+        "name": "ALTA Lenders Policy",
         "type": "lenders",
         "policyAmount": 800000,
         "useSimultaneousRates": true,
@@ -45,6 +50,7 @@
         "effectiveDate": "2019-05-10"
       },
       {
+        "name": "ALTA Owner's Policy",
         "type": "owners",
         "policyAmount": 1100000,
         "useSimultaneousRates": true,


### PR DESCRIPTION
## Added fields to quoteRequest.json file.

**Notes for @switchspan ** 

- We have propertyType, unitType, and type fields.  These seen very similar and we may be able to remove the type field.
- Added the appraisalForm and appraisalType fields, we may want to look at the naming or location of these.  They are needed to get appraisal fees from 24 Seven Fees.
- Added names to the policiesRequested objects.
- There are some fields that we have in this object that I have not seen used yet.  These include APN, sqFootage, lotSize, occupancy, unitType.  We may want to look at removing these or making them optional.

Please advise and I can update the quoteRequest.json file again and create another pull request or modify this one.